### PR TITLE
chore: ignore logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .coverage
 htmlcov/
 coverage.xml
+logs/


### PR DESCRIPTION
Adds `logs/` to .gitignore so the untracked local logs directory stops showing up in git status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)